### PR TITLE
Fix deprecation warning in spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ spec/dummy/db/*.sqlite3
 spec/dummy/db/*.sqlite3-journal
 spec/dummy/log/*.log
 spec/dummy/tmp/
+coverage

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,10 +48,12 @@ GEM
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     diff-lcs (1.3)
+    docile (1.3.1)
     erubis (2.7.0)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
     i18n (0.8.6)
+    json (2.1.0)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.6)
@@ -112,6 +114,11 @@ GEM
       rspec-mocks (~> 3.6.0)
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -136,6 +143,7 @@ DEPENDENCIES
   pry
   rails (~> 5.0.2)
   rspec-rails
+  simplecov
   sqlite3
 
 BUNDLED WITH

--- a/presenter-rails.gemspec
+++ b/presenter-rails.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency "pry"
+  s.add_development_dependency "simplecov"
 end

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -28,8 +28,7 @@ describe Presenter::Helper do
         let(:failed_presenter) { test.present admin }
 
         it 'should allow a user to pass in extra arguments to send to the presenter' do
-          expect { admin_presenter }.to_not raise_error Presenter::Error
-          expect { admin_presenter }.to_not raise_error ArgumentError
+          expect { admin_presenter }.to_not raise_error
           expect(admin_presenter.subject).to eq admin
           expect(admin_presenter.age).to eq 30
         end
@@ -47,8 +46,7 @@ describe Presenter::Helper do
         end
 
         it 'should allow a user to pass in a block to set arguments in a block' do
-          expect { admin_presenter }.to_not raise_error Presenter::Error
-          expect { admin_presenter }.to_not raise_error ArgumentError
+          expect { admin_presenter }.to_not raise_error
           expect(admin_presenter.first.age).to eql 3
         end
 
@@ -58,8 +56,7 @@ describe Presenter::Helper do
           context 'argument provided' do
             let(:args) { [30] }
             it 'should not error' do
-              expect { admin_presenter }.to_not raise_error Presenter::Error
-              expect { admin_presenter }.to_not raise_error ArgumentError
+              expect { admin_presenter }.to_not raise_error
               expect(admin_presenter.first.subject).to eq admin
               expect(admin_presenter.first.age).to eq 30
             end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,3 +1,8 @@
+require 'simplecov'
+SimpleCov.start do
+  add_filter '/spec/'
+end
+
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 require 'pry'

--- a/spec/user_presenter_spec.rb
+++ b/spec/user_presenter_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 # Use this spec to test the application of rails presenter
 describe UserPresenter do
   let(:user) { User.create(first_name: "Sam", last_name: "Sargent")}
-  let(:presenter) { UserPresenter.new(user, 'Finn') }
+  let(:presenter) { TestUserPresenter.new(user, 'Finn') }
 
   describe 'overriding the initialize' do
     it 'should allow the initialize to be overridden' do
@@ -18,7 +18,7 @@ describe UserPresenter do
   end
 end
 
-class UserPresenter < ApplicationPresenter
+class TestUserPresenter < ApplicationPresenter
   attr_reader :user
 
   def initialize(user, first_name)


### PR DESCRIPTION
How?
- Replace instances of `expect {..}.to_not raise_error(SpecificError)` to `expect {..}.to_not raise_error`

Added simplecov to the project
Why?
- To track test coverage

Fixed issue in 'spec/user_presenter_spec.rb'
How?
- Renamed UserPresenter to TestUserPresenter in the spec
Why?
- There is already a UserPresenter in the project. Overwriting it in user_presenter_spec was causing errors when running the whole test suite.