### PR TITLE
Inject the code to require presenter-rails and autoload the presenter directory when performing the install generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ Run the install generator
 ```bash
 $ rails g presenter:install
 ```
-Add this line to the top of your application.rb
+It will add this line to your application.rb
 ```ruby
 # config/application.rb
 require 'presenter'
 ```
-Followed by this line inside the Application class
+And this line inside the Application class
 ```ruby
 # config/application.rb
 module YourAppName

--- a/lib/generators/presenter/install/USAGE
+++ b/lib/generators/presenter/install/USAGE
@@ -7,3 +7,9 @@ Example:
     This will create:
         app/presenters
         app/presenters/application_presenter.rb
+
+    This will inject:
+        require 'presenter'
+        config.autoload_paths << Rails.root.join('app/presenters')
+    Into config/application.rb
+

--- a/lib/generators/presenter/install/install_generator.rb
+++ b/lib/generators/presenter/install/install_generator.rb
@@ -1,11 +1,35 @@
 module Presenter
   module Generators
     class InstallGenerator < Rails::Generators::Base
+      APPLICATION_RB = Rails.root.join('config/application.rb')
+
       source_root File.expand_path('../templates', __FILE__)
       class_option :doc, type: :boolean, default: true, desc: 'Include commented documentation'
+      class_option :require, type: :boolean, default: true, desc: 'Require presenter,
+        and autoload the presenter directory'
 
       def generate_application_presenter
         template 'application_presenter.template', 'app/presenters/application_presenter.rb'
+      end
+
+      def require_and_load_presenter
+        return false unless options[:require]
+        inject_into_autoload_path
+        inject_require_into_application_rb
+      end
+
+      private
+
+      def inject_into_autoload_path
+        insert_into_file APPLICATION_RB,
+                         "\t\tconfig.autoload_paths << Rails.root.join('app/presenters')\n\n",
+                         after: "class Application < Rails::Application\n"
+      end
+
+      def inject_require_into_application_rb
+        insert_into_file APPLICATION_RB,
+                         "require 'presenter'\n\n",
+                         before: /module .*\n\s+class Application \< Rails::Application/
       end
     end
   end


### PR DESCRIPTION
Why?
- Makes installation easier by taking out 2 steps

How?
- Using Thor#inject_into_file to add the relevent lines in the correct place
- Added an option (--no-require) to prevent these options from being injected in